### PR TITLE
fix hashlib usage compatibility with pypy3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
 version: ~> 1.0
 language: python
 cache: pip
+dist: bionic
 python:
   - "2.7"
   - "3.5"
   - "3.6"
   - "3.7"
   - "3.8"
+  - "pypy3"
 install: pip install .[test] codecov
 script: ./run-tests.py
 before_cache: rm -f $HOME/.cache/pip/log/debug.log

--- a/csv23/shortcuts.py
+++ b/csv23/shortcuts.py
@@ -206,7 +206,7 @@ else:
                 buf = f.buffer
                 for rows in iterslices(rows, 1000):
                     writer.writerows(rows)
-                    hashsum.update(buf.getbuffer())
+                    hashsum.update(bytes(buf.getbuffer()))
                     # NOTE: f.truncate(0) would prepend zero-bytes
                     f.seek(0)
                     f.truncate()

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,35,36,37,38}
+envlist = py{27,35,36,37,38},pypy3
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
PyPy3's hashlib fails when passed a memoryview object (i.e.
BytesIO.getbuffer()).  Convert it to bytes instead in order to fix
compatibility.  While this isn't necessary for CPython, it should not
cause any issues.

Also enabling testing with pypy3.

PyPy3 bug: https://foss.heptapod.net/pypy/pypy/issues/3217