### PR TITLE
use utf-16-le to fix test failures on big endian

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ import pytest
 
 PY2 = (sys.version_info.major == 2)
 
-ENCODING = ['utf-8', 'utf-16', 'utf-8-sig', 'latin9']
+ENCODING = ['utf-8', 'utf-16-le', 'utf-8-sig', 'latin9']
 
 CLEAN = {'utf-8', 'latin9'}
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -11,7 +11,7 @@ from csv23._common import is_8bit_clean, csv_args
     ('u8', True),
     ('u16', False),
     ('windows-1252', True),
-    ('utf-16', False),
+    ('utf-16-le', False),
     ('IBM437', True),
     ('cp500', False),
     ('UTF-16BE', False),

--- a/tests/test_shortcuts.py
+++ b/tests/test_shortcuts.py
@@ -251,7 +251,8 @@ def test_write_csv_filename(tmp_path, filename, rows, header, encoding, expected
     (ROWS, HEADER, ENCODING, 'sha256', 'ddbbcd4f1b15f3834f5a9ee59a6ee7837'
                                        '7474df6d9b017216b89129ecc394608'),
     (ROWS, None, ENCODING, 'md5', '67bac4eb7cd16ea8eaf454eafa559d34'),
-    (ROWS, None, 'utf-16', 'sha1', 'b0e0578b8149619569a4f56a3e6d05fed7de788f'),
+    (ROWS, None, 'utf-16-le', 'sha1', '3f49d7d103251f7d4db79ca6eac67f239c'
+                                      '71327a'),
     (ROWS, None, None, 'sha256', (TypeError, r'need encoding')),
 ])
 def test_write_csv_hash(rows, header, encoding, hash_name, expected):
@@ -273,7 +274,7 @@ def test_write_csv_hash(rows, header, encoding, hash_name, expected):
 @pytest.csv23.py3only
 @pytest.mark.parametrize('rows, header, encoding, hash_name', [
     (ROWS, HEADER, ENCODING, 'sha256'),
-    (ROWS, HEADER, 'utf-16', 'sha1'),
+    (ROWS, HEADER, 'utf-16-le', 'sha1'),
 ])
 def test_write_csv_equivalence(tmp_path, rows, header, encoding, hash_name):
     if sys.version_info < (3, 6):


### PR DESCRIPTION
Use utf-16-le instead of utf-16 to fix test failures on big endian
hardware.  Plain utf-16 uses host endianness, and therefore yields
different results on little endian and big endian machines.
On the latter, the resulting hash differs from the one specified in test
and the test fails.

This also needs the stored hash value to change, as utf-16 writes BOM
while utf-16-{le,be} do not.  Python does not seem to provide an easy
way to force specific endianness and write BOM at the same time, so just
updating the checksum seems to be the easiest solution to the problem.